### PR TITLE
Additional error handling + absolute path for dups/cat/sha

### DIFF
--- a/explorer-dsu/dsu_s.json
+++ b/explorer-dsu/dsu_s.json
@@ -1,1 +1,1 @@
-{"dsus":[{"key":"BBudGH6ySHG6GUHN8ogNrTWdgS8gSbY6g2daYphM2v6kJDB4bgsFrdgfqv7gEXavd7wzzNtv8aFXn8zjU7bPBB2WB","name":"default","type":"filesystem like dsu?"}]}
+{"dsus":[{"key":"BBudGH6ySHG6GUHN8ogNrTWdCpq7FsYr89m9wgTprV93a1VdnUJSpLqbEniT8BvCJCQciJnMeYGUrETXCV4MzQMzF","name":"default","type":"filesystem like dsu?"}]}


### PR DESCRIPTION
- Fixed cat,dups,sha256 not using absolute path, commands like cat docs/doc1.txt or dups docs now work.
- Error handling